### PR TITLE
Added optional parameter for custom tweet formats

### DIFF
--- a/formatter.js
+++ b/formatter.js
@@ -1,7 +1,7 @@
 var moment = require("moment");
 var twttr = require('twitter-text');
 
-module.exports = function(webhook, cb){
+module.exports = function(webhook, customFormat, cb){
 	if(!webhook) return cb('should provide a webhook', null)
 	
 	var label = webhook.webhook.label;
@@ -23,12 +23,17 @@ module.exports = function(webhook, cb){
 				talks.map(function(talk){
 					var talkDescription = talk.description;
 
-					description = 'New talk:';
+					if (customFormat !== undefined && customFormat === 'custom') {
+						description = "LNUG talk - @" + talk.speaker.twitter + " - " + talk.title;
+					}
+					else {
+						description = 'New talk:';
 
-					//start text creation
-					description += ' ' + eventURL;
-					description += ' ' + talkDescription.slice(0, getRemainingChars(description)) + '...'
-					
+						//start text creation
+						description += ' ' + eventURL;
+						description += ' ' + talkDescription.slice(0, getRemainingChars(description)) + '...'
+					}
+
 					//check tweet
 					checkTweet(description, function(err, res){
 						if(err) return cb(err, null)

--- a/index.js
+++ b/index.js
@@ -17,9 +17,18 @@ module.exports =  function(config){
 	);
 
 	return {
-		init : function(webhook, cb){
-			var self = this
-			formatter(webhook, function(err, res){
+		// customFormat parameter is optional
+		init : function(webhook, customFormat, cb){
+			var self = this;
+
+			// check if customFormat parameter has been provided - if not,
+			// need to reassign cb parameter
+			if (cb === undefined && customFormat !== undefined && typeof customFormat === 'function') {
+				cb = customFormat;
+				customFormat = undefined;
+			}
+
+			formatter(webhook, customFormat, function(err, res){
 				if(err) throw new Error(err)
 				self.send(res, cb)
 			})

--- a/test.js
+++ b/test.js
@@ -147,8 +147,43 @@ test('talk tweets match expected results', function (t) {
     tweetAsArray = res.split('');
     tweetAsArray.splice(25, 5);
     res = tweetAsArray.join('');
+
     tweetsSent.push(res);
 
+    // wait for both tweets to be sent (i.e. stored in the array)
+    if (tweetsSent.length === 2) {
+      // may need to swap tweets around before check
+      if (tweetsSent[0] !== tweet1) {
+        tempTweet = tweetsSent[0];
+        tweetsSent[0] = tweetsSent[1];
+        tweetsSent[1] = tempTweet;
+      }
+
+      t.equal(tweetsSent[0], tweet1, 'tweet 1 matches expected result');
+      t.equal(tweetsSent[1], tweet2, 'tweet 2 matches expected result');
+    }
+    else if (tweetsSent.length > 2) {
+      t.fail('too many tweets sent');
+    }
+  });
+});
+
+//  This test calls init(), providing the optional second parameter
+// as "custom", which builds the tweet using a custom format.
+// Otherwise, the test is the same as the 'talk tweets match expected results'
+// test directly above this one.
+test('custom talk tweets match expected results', function (t) {
+  var tweetsSent = [],
+    tweet1 = "LNUG talk - @bcnjs - Serious text editing in the browser",
+    tweet2 = "LNUG talk - @bcnjs - Development environments using fig";
+
+  t.plan(2);
+
+  giteventsTwitter.init(fakeDataTalks, "custom", function (err, res) {
+    if (err) {
+      return console.error(err);
+    }
+    tweetsSent.push(res);
     // wait for both tweets to be sent (i.e. stored in the array)
     if (tweetsSent.length === 2) {
       // may need to swap tweets around before check


### PR DESCRIPTION
This adds an optional parameter to the `init()` function that enables a selection to be made from multiple tweet formats.

If the optional parameter is not provided, the code behaves exactly as before. The existing tests pass without any changes being necessary.

The signature of `init()` changes from `(webhook, cb)` to `(webhook, customFormat, cb)`.

The function exported by `formatter.js` changes to support the new `customFormat` parameter. It also accepts an extra parameter, and the signature is the same as for `init()`.

The `formatter.js function` checks whether the `customFormat` parameter is defined and whether the string matches a known format. If so, it creates a tweet using the new format. Otherwise, the tweet is created exactly as before.

A new test has been added to check that the results of the new functionality are as expected.
